### PR TITLE
Report spark max temperatures and add auto-disable code

### DIFF
--- a/src/main/java/frc/robot/lib/Lib199Subsystem.java
+++ b/src/main/java/frc/robot/lib/Lib199Subsystem.java
@@ -1,0 +1,49 @@
+package frc.robot.lib;
+
+import java.util.ArrayList;
+import java.util.function.Consumer;
+
+import edu.wpi.first.wpilibj2.command.Subsystem;
+
+public class Lib199Subsystem implements Subsystem {
+
+    private static final Lib199Subsystem INSTANCE = new Lib199Subsystem();
+    private static final ArrayList<Runnable> periodicMethods = new ArrayList<>();
+    private static final ArrayList<Runnable> periodicSimulationMethods = new ArrayList<>();
+    private static final Consumer<Runnable> RUN_RUNNABLE = Runnable::run;
+
+    static {
+        ensureRegistered();
+    }
+    
+    private static boolean registered = false;
+
+    private static void ensureRegistered() {
+        if(registered) {
+            return;
+        }
+        registered = true;
+        INSTANCE.register();
+    }
+
+    public static void registerPeriodic(Runnable method) {
+        periodicMethods.add(method);
+    }
+
+    public static void simulationPeriodic(Runnable method) {
+        periodicSimulationMethods.add(method);
+    }
+
+    @Override
+    public void periodic() {
+        periodicMethods.forEach(RUN_RUNNABLE);
+    }
+
+    @Override
+    public void simulationPeriodic() {
+        periodicSimulationMethods.forEach(RUN_RUNNABLE);
+    }
+
+    private Lib199Subsystem() {}
+
+}

--- a/src/main/java/frc/robot/lib/MotorControllerFactory.java
+++ b/src/main/java/frc/robot/lib/MotorControllerFactory.java
@@ -84,6 +84,8 @@ public class MotorControllerFactory {
         spark = MockSparkMax.createMockSparkMax(id, CANSparkMaxLowLevel.MotorType.kBrushless);
     }
 
+    MotorErrors.reportSparkMaxTemp(spark);
+
     MotorErrors.reportError(spark.restoreFactoryDefaults());
     MotorErrors.reportError(spark.follow(ExternalFollower.kFollowerDisabled, 0));
     MotorErrors.reportError(spark.setIdleMode(IdleMode.kBrake));

--- a/src/main/java/frc/robot/lib/MotorErrors.java
+++ b/src/main/java/frc/robot/lib/MotorErrors.java
@@ -1,5 +1,6 @@
 package frc.robot.lib;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
@@ -15,6 +16,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 public final class MotorErrors {
 
     private static final HashMap<Integer, CANSparkMax> temperatureSparks = new HashMap<>();
+    private static final ArrayList<Integer> overheatedSparks = new ArrayList<>();
     private static final HashMap<CANSparkMax, Short> flags = new HashMap<>();
     private static final HashMap<CANSparkMax, Short> stickyFlags = new HashMap<>();
 
@@ -108,8 +110,12 @@ public final class MotorErrors {
         temperatureSparks.forEach((port, spark) -> {
             double temp = spark.getMotorTemperature();
             SmartDashboard.putNumber("Port " + port + " Spark Max Temp", temp);
-            if(temp >= 100) {
-                System.err.println("Port " + port + " spark max is operating at " + temp + " degrees Celsius! It will be disabled until the robot code is restarted.");
+            // Check if temperature exceeds the setpoint or if the contoller has already overheated to prevent other code from resetting the current limit after the controller has cooled
+            if(temp >= 100 || overheatedSparks.contains(port)) {
+                if(!overheatedSparks.contains(port)) {
+                    overheatedSparks.add(port);
+                    System.err.println("Port " + port + " spark max is operating at " + temp + " degrees Celsius! It will be disabled until the robot code is restarted.");
+                }
                 spark.setSmartCurrentLimit(1);
             }
         });

--- a/src/main/java/frc/robot/lib/MotorErrors.java
+++ b/src/main/java/frc/robot/lib/MotorErrors.java
@@ -109,6 +109,7 @@ public final class MotorErrors {
             double temp = spark.getMotorTemperature();
             SmartDashboard.putNumber("Port " + port + " Spark Max Temp", temp);
             if(temp >= 100) {
+                System.err.println("Port " + port + " spark max is operating at " + temp + " degrees Celsius! It will be disabled until the robot code is restarted.");
                 spark.setSmartCurrentLimit(1);
             }
         });

--- a/src/test/java/frc/robot/lib/Lib199SubsystemTest.java
+++ b/src/test/java/frc/robot/lib/Lib199SubsystemTest.java
@@ -1,0 +1,34 @@
+package frc.robot.lib;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+
+public class Lib199SubsystemTest {
+
+    @Test
+    public void testPeriodic() {
+        AtomicInteger counter = new AtomicInteger(0);
+        Lib199Subsystem.registerPeriodic(() -> counter.addAndGet(1));
+        assertEquals("Periodic method called before CommandScheduler.run", 0, counter.get());
+        CommandScheduler.getInstance().run();
+        assertEquals("Periodic method called more than once or not at all", 1, counter.get());
+    }
+
+    @Test
+    public void testSimulationPeriodic() {
+        assumeTrue(RobotBase.isSimulation());
+        AtomicInteger counter = new AtomicInteger(0);
+        Lib199Subsystem.registerPeriodic(() -> counter.addAndGet(1));
+        assertEquals("Simulation periodic method called before CommandScheduler.run", 0, counter.get());
+        CommandScheduler.getInstance().run();
+        assertEquals("Simulation periodic method called more than once or not at all", 1, counter.get());
+    }
+
+}

--- a/src/test/java/frc/robot/lib/MotorErrorsTest.java
+++ b/src/test/java/frc/robot/lib/MotorErrorsTest.java
@@ -173,10 +173,13 @@ public class MotorErrorsTest extends ErrStreamTest {
         CommandScheduler.getInstance().run();
         assertEquals(75, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
         assertEquals(50, spark.getSmartCurrentLimit());
+        assertEquals(0, errStream.size());
         spark.setTemperature(100);
         CommandScheduler.getInstance().run();
         assertEquals(100, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
         assertEquals(1, spark.getSmartCurrentLimit());
+        assertNotEquals(0, errStream.size());
+        errStream.reset();
         spark.setTemperature(110);
         CommandScheduler.getInstance().run();
         assertEquals(110, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
@@ -185,6 +188,7 @@ public class MotorErrorsTest extends ErrStreamTest {
         CommandScheduler.getInstance().run();
         assertEquals(50, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
         assertEquals(1, spark.getSmartCurrentLimit());
+        assertEquals(0, errStream.size());
     }
 
 }

--- a/src/test/java/frc/robot/lib/MotorErrorsTest.java
+++ b/src/test/java/frc/robot/lib/MotorErrorsTest.java
@@ -10,11 +10,13 @@ import com.revrobotics.CANSparkMax.FaultID;
 
 import org.junit.Test;
 
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.lib.testUtils.ErrStreamTest;
 
 public class MotorErrorsTest extends ErrStreamTest {
 
-    public class SensorFaultSparkMax {
+    public static class SensorFaultSparkMax {
         public short getFaults() {
             return (short)FaultID.kSensorFault.value;
         }
@@ -24,7 +26,7 @@ public class MotorErrorsTest extends ErrStreamTest {
         }
     }
 
-    public class StickySensorFaultSparkMax {
+    public static class StickySensorFaultSparkMax {
         public short getStickyFaults() {
             return (short)FaultID.kSensorFault.value;
         }
@@ -33,6 +35,48 @@ public class MotorErrorsTest extends ErrStreamTest {
             return faultID == FaultID.kSensorFault;
         }
     }
+
+    public static interface TemperatureSparkMax {
+
+        public void setTemperature(double temperature);
+        public int getSmartCurrentLimit();
+        public double getMotorTemperature();
+        public CANError setSmartCurrentLimit(int limit);
+
+        public static class Instance {
+
+            private int smartCurrentLimit = 50;
+            private double temperature = 30;
+            private final int id;
+
+            public Instance(int id) {
+                this.id = id;
+            }
+
+            public void setTemperature(double temperature) {
+                this.temperature = temperature;
+            }
+
+            public int getSmartCurrentLimit() {
+                return smartCurrentLimit;
+            }
+
+            public double getMotorTemperature() {
+	        	return temperature;
+            }
+
+            public CANError setSmartCurrentLimit(int limit) {
+                smartCurrentLimit = limit;
+    		    return CANError.kOk;
+            }
+            
+            public int getDeviceId() {
+                return id;
+            }
+        }
+
+    }
+
     @Test
     public void testOkErrors() {
         errStream.reset();
@@ -107,6 +151,40 @@ public class MotorErrorsTest extends ErrStreamTest {
     @Test
     public void testDummySparkMax() {
         DummySparkMaxAnswerTest.assertTestResponses(MotorErrors.createDummySparkMax());
+    }
+
+    @Test
+    public void testReportSparkMaxTemp() {
+        doTestReportSparkMaxTemp(0);
+        doTestReportSparkMaxTemp(1);
+        doTestReportSparkMaxTemp(2);
+    }
+
+    private void doTestReportSparkMaxTemp(int id) {
+        TemperatureSparkMax spark = (TemperatureSparkMax)Mocks.createMock(CANSparkMax.class, new TemperatureSparkMax.Instance(id), TemperatureSparkMax.class);
+        MotorErrors.reportSparkMaxTemp((CANSparkMax)spark);
+        spark.setSmartCurrentLimit(50);
+        spark.setTemperature(50);
+        CommandScheduler.getInstance().run();
+        String smartDashboardKey = "Port " + id + " Spark Max Temp";
+        assertEquals(50, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
+        assertEquals(50, spark.getSmartCurrentLimit());
+        spark.setTemperature(75);
+        CommandScheduler.getInstance().run();
+        assertEquals(75, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
+        assertEquals(50, spark.getSmartCurrentLimit());
+        spark.setTemperature(100);
+        CommandScheduler.getInstance().run();
+        assertEquals(100, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
+        assertEquals(1, spark.getSmartCurrentLimit());
+        spark.setTemperature(110);
+        CommandScheduler.getInstance().run();
+        assertEquals(110, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
+        assertEquals(1, spark.getSmartCurrentLimit());
+        spark.setTemperature(50);
+        CommandScheduler.getInstance().run();
+        assertEquals(50, SmartDashboard.getNumber(smartDashboardKey, 0), 0.01);
+        assertEquals(1, spark.getSmartCurrentLimit());
     }
 
 }


### PR DESCRIPTION
This code adds the temperatures of all `CANSparkMax` motor controllers to `SmartDashboard` and sets their smart current limit to `1` if they exceed 100 degrees Celsius. In this case, a message will be printed to the console, and the robot code will need to be restarted to reset the affected controllers.