### PR TITLE
Deprecate `CachedSparkMax`

### DIFF
--- a/src/main/java/org/carlmontrobotics/lib199/CachedSparkMax.java
+++ b/src/main/java/org/carlmontrobotics/lib199/CachedSparkMax.java
@@ -4,6 +4,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxPIDController;
 
+@Deprecated
 public class CachedSparkMax extends CANSparkMax {
 
     private RelativeEncoder encoder;

--- a/src/main/java/org/carlmontrobotics/lib199/MotorControllerFactory.java
+++ b/src/main/java/org/carlmontrobotics/lib199/MotorControllerFactory.java
@@ -120,7 +120,7 @@ public class MotorControllerFactory {
   public static CANSparkMax createSparkMax(int id, MotorConfig config) {
     CANSparkMax spark;
     if (RobotBase.isReal()) {
-      spark = new CachedSparkMax(id, CANSparkMaxLowLevel.MotorType.kBrushless);
+      spark = new CANSparkMax(id, CANSparkMaxLowLevel.MotorType.kBrushless);
       if (spark.getFirmwareVersion() == 0) {
         spark.close();
         System.err.println("SparkMax on port: " + id + " is not connected!");


### PR DESCRIPTION
Fixes #46. This deprecates `CachedSparkMax` because Rev's implementation is better (see issue). This should be tested before merging to make sure that CAN usage doesn't spike. (It might be a good idea to make sure to use some `getEncoder` calls in periodic loops to stress test the change). `CachedSparkMax` should be deleted in an upcoming major release.