### PR TITLE
Fix units passed to CANcoderSimState.setRawPosition().

### DIFF
--- a/src/main/java/org/carlmontrobotics/lib199/sim/MockedCANCoder.java
+++ b/src/main/java/org/carlmontrobotics/lib199/sim/MockedCANCoder.java
@@ -34,7 +34,7 @@ public class MockedCANCoder {
     }
 
     public void update() {
-        sim.setRawPosition((int) (position.get() * kCANCoderCPR));
+        sim.setRawPosition(position.get() / kCANCoderCPR);
     }
 
     public void setGearing(double gearing) {


### PR DESCRIPTION
As of Phoenix6, units should be rotations (and therefore also should not be cast to integers).