### PR TITLE
Make safeMode tests pass even when run alone.

### DIFF
--- a/src/main/java/org/carlmontrobotics/lib199/safeMode/SafeJoystick.java
+++ b/src/main/java/org/carlmontrobotics/lib199/safeMode/SafeJoystick.java
@@ -108,7 +108,7 @@ public class SafeJoystick {
      * @param pov The POV to read
      * @return The value of the POV
      */
-    public double getPOV(int pov) {
+    public int getPOV(int pov) {
         if (SafeMode.isEnabled() && safeDisabledPOV.containsKey(pov) && safeDisabledPOV.get(pov).contains(unsafeJoystick.getPOV(pov))) {
             return -1;
         } else {

--- a/src/test/java/org/carlmontrobotics/lib199/MotorControllerFactoryTest.java
+++ b/src/test/java/org/carlmontrobotics/lib199/MotorControllerFactoryTest.java
@@ -3,7 +3,7 @@ package org.carlmontrobotics.lib199;
 import static org.junit.Assert.assertEquals;
 
 import org.carlmontrobotics.lib199.testUtils.ErrStreamTest;
-import org.carlmontrobotics.lib199.testUtils.SimDeviceTestRule;
+import org.carlmontrobotics.lib199.testUtils.TestRules;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,9 +11,9 @@ import org.junit.Test;
 public class MotorControllerFactoryTest extends ErrStreamTest {
 
     @ClassRule
-    public static SimDeviceTestRule.Class simClassRule = new SimDeviceTestRule.Class();
+    public static TestRules.InitializeHAL simClassRule = new TestRules.InitializeHAL();
     @Rule
-    public SimDeviceTestRule.Test simTestRule = new SimDeviceTestRule.Test();
+    public TestRules.ResetSimDeviceSimData simTestRule = new TestRules.ResetSimDeviceSimData();
 
     @Test
     // AutoClosable.close() throws Exception

--- a/src/test/java/org/carlmontrobotics/lib199/safeMode/SafeJoystickTest.java
+++ b/src/test/java/org/carlmontrobotics/lib199/safeMode/SafeJoystickTest.java
@@ -2,10 +2,18 @@ package org.carlmontrobotics.lib199.safeMode;
 
 import static org.junit.Assert.*;
 
+import org.carlmontrobotics.lib199.testUtils.TestRules;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import edu.wpi.first.wpilibj.GenericHID;
 
 public class SafeJoystickTest {
 
+    @ClassRule
+    public static TestRules.InitializeHAL classRule = new TestRules.InitializeHAL();
+
+    @Test
     public void testSafeJoystick() {
         GenericHID normalJoystick = createDummyJoystick(0);
         GenericHID unsafeJoystick1 = createDummyJoystick(1);
@@ -85,7 +93,7 @@ public class SafeJoystickTest {
         assertTrue(safeJoystick1.getRawButton(1));
         assertTrue(safeJoystick1.getRawButtonPressed(1));
         assertTrue(safeJoystick1.getRawButtonReleased(1));
-        assertEquals(0.5, safeJoystick1.getRawAxis(0), 0.01);
+        assertEquals(0.0, safeJoystick1.getRawAxis(0), 0.01);
         assertEquals(0.5, safeJoystick1.getRawAxis(1), 0.01);
         assertEquals(1.0, safeJoystick1.getRawAxis(2), 0.01);
         assertEquals(-1, safeJoystick1.getPOV(0));

--- a/src/test/java/org/carlmontrobotics/lib199/safeMode/SafeModeCommandsTest.java
+++ b/src/test/java/org/carlmontrobotics/lib199/safeMode/SafeModeCommandsTest.java
@@ -4,12 +4,17 @@ import static org.junit.Assert.*;
 
 import java.util.function.Function;
 
+import org.carlmontrobotics.lib199.testUtils.TestRules;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
 public class SafeModeCommandsTest {
+
+    @ClassRule
+    public static TestRules.InitializeHAL classRule = new TestRules.InitializeHAL(); 
 
     @Test
     public void testSafeCommand() {

--- a/src/test/java/org/carlmontrobotics/lib199/safeMode/SafeModeTest.java
+++ b/src/test/java/org/carlmontrobotics/lib199/safeMode/SafeModeTest.java
@@ -9,6 +9,8 @@ import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+import org.carlmontrobotics.lib199.testUtils.TestRules;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -16,6 +18,8 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
 public class SafeModeTest {
 
+    @ClassRule
+    public static TestRules.InitializeHAL classRule = new TestRules.InitializeHAL(); 
     // Test SafeMode.java using JUnit
 
     @Test

--- a/src/test/java/org/carlmontrobotics/lib199/sim/MockPheonixControllerTest.java
+++ b/src/test/java/org/carlmontrobotics/lib199/sim/MockPheonixControllerTest.java
@@ -8,7 +8,7 @@ import com.ctre.phoenix.motorcontrol.can.BaseMotorController;
 
 import org.carlmontrobotics.lib199.Mocks;
 import org.carlmontrobotics.lib199.testUtils.SafelyClosable;
-import org.carlmontrobotics.lib199.testUtils.SimDeviceTestRule;
+import org.carlmontrobotics.lib199.testUtils.TestRules;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,9 +20,9 @@ import edu.wpi.first.wpilibj.simulation.PWMSim;
 public abstract class MockPheonixControllerTest {
     
     @ClassRule
-    public static SimDeviceTestRule.Class simClassRule = new SimDeviceTestRule.Class();
+    public static TestRules.InitializeHAL simClassRule = new TestRules.InitializeHAL();
     @Rule
-    public SimDeviceTestRule.Test simTestRule = new SimDeviceTestRule.Test();
+    public TestRules.ResetSimDeviceSimData simTestRule = new TestRules.ResetSimDeviceSimData();
 
     protected abstract BaseMotorController createController(int portPWM);
 

--- a/src/test/java/org/carlmontrobotics/lib199/sim/MockedSparkEncoderTest.java
+++ b/src/test/java/org/carlmontrobotics/lib199/sim/MockedSparkEncoderTest.java
@@ -13,7 +13,7 @@ import com.revrobotics.RelativeEncoder;
 import org.carlmontrobotics.lib199.Mocks;
 import org.carlmontrobotics.lib199.REVLibErrorAnswer;
 import org.carlmontrobotics.lib199.testUtils.SafelyClosable;
-import org.carlmontrobotics.lib199.testUtils.SimDeviceTestRule;
+import org.carlmontrobotics.lib199.testUtils.TestRules;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,9 +24,9 @@ import edu.wpi.first.wpilibj.simulation.SimDeviceSim;
 public class MockedSparkEncoderTest {
 
     @ClassRule
-    public static SimDeviceTestRule.Class simClassRule = new SimDeviceTestRule.Class(); 
+    public static TestRules.InitializeHAL simClassRule = new TestRules.InitializeHAL(); 
     @Rule
-    public SimDeviceTestRule.Test simTestRule = new SimDeviceTestRule.Test(); 
+    public TestRules.ResetSimDeviceSimData simTestRule = new TestRules.ResetSimDeviceSimData(); 
 
     @Test
     public void testDeviceCreation() {

--- a/src/test/java/org/carlmontrobotics/lib199/testUtils/TestRules.java
+++ b/src/test/java/org/carlmontrobotics/lib199/testUtils/TestRules.java
@@ -7,15 +7,15 @@ import org.junit.runners.model.Statement;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.SimDeviceSim;
 
-public class SimDeviceTestRule {
+public class TestRules {
 
-    public static class Class implements TestRule {
+    public static class InitializeHAL implements TestRule {
         @Override
         public Statement apply(Statement base, Description description) {
             return new Statement(){
                 @Override
                 public void evaluate() throws Throwable {
-                    // HAL must be initialized or SimDeviceSim.resetData() will crash
+                    // HAL must be initialized or SimDeviceSim.resetData() will crash and SmartDashboard might not work.
                     HAL.initialize(500, 0);
                     base.evaluate();
                     HAL.shutdown();
@@ -24,7 +24,7 @@ public class SimDeviceTestRule {
         }
     }
 
-    public static class Test implements TestRule {
+    public static class ResetSimDeviceSimData implements TestRule {
         @Override
         public Statement apply(Statement base, Description description) {
             return new Statement(){


### PR DESCRIPTION
Ensures the HAL is initialized before running the safeMode tests because if it isn't SmartDashboard doesn't work properly and the tests fail. This is not normally seen when running all tests because other tests were initializing the HAL.

Also rename some classes for clarity.