### PR TITLE
Reduce `MockedCANCoderTest` Fail Rate

### DIFF
--- a/src/test/java/org/carlmontrobotics/lib199/sim/MockedCANCoderTest.java
+++ b/src/test/java/org/carlmontrobotics/lib199/sim/MockedCANCoderTest.java
@@ -30,13 +30,18 @@ public class MockedCANCoderTest {
         // Consider the current position to be 0 rotations.
         canCoder.setPosition(0.0);
 
+        // Wait for the CANCoder to update the position. This appears to happen on a separate thread.
+        canCoder.getPosition().waitForUpdate(1.0);
+        canCoder.getPosition().waitForUpdate(1.0);
+        // Verify that the position was correctly reset
+        assertEquals(0.0, canCoder.getPosition().getValueAsDouble(), 0.001);
+
         // Set the position to 0.42 rotations via the SimDevice interface
         SimDeviceSim canCoderSim = new SimDeviceSim("CANCoder", 0);
         canCoderSim.getDouble("count").set(0.42 * MockedCANCoder.kCANCoderCPR);
 
-        // Wait for the CANCoder to update the position. This appears to happen on a separate thread.
         canCoder.getPosition().waitForUpdate(1.0);
-
+        canCoder.getPosition().waitForUpdate(1.0);
         assertEquals(0.42, canCoder.getPosition().getValueAsDouble(), 0.001);
     }
 


### PR DESCRIPTION
I was running into a bug where `MockedCANCoderTest` was failing semi-regularly. This PR introduces three additional waits to reduce this occurrence. I tried a couple configurations.

Adding a check after setting the position to `0` and performing two waits before each check seemed to be the best combination of functionality and clarity.

(Note: From my testing, it was not clear that increasing the timeout parameter or changing the location of the wait calls had a significant effect on the failure rate.)

Original Failure Rate: `18/100` (The denominator is not a typo. This number is from a test 10x smaller than the others.)
Failure rate after adding wait on line 34: `38/1000`
Failure after adding waits on lines 34 **and** 44: `1/1000`
Failure after adding waits on lines 34, 44, **and** 35: `2/1000`

These last two results both have a `<1%` failure rate, so they are basically identical. I kept the extra wait in because it's clearer just to perform two waits before reading any data. I tried to run some more detailed tests on them, but they didn't return reasonable results.