### PR TITLE
Link Phoenix 6 Javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ javadoc {
         links 'https://www.kauailabs.com/public_files/navx-mxp/apidocs/java/'
         links 'https://pathplanner.dev/api/java/'
         links 'https://api.ctr-electronics.com/phoenix/release/java/'
+        links 'https://api.ctr-electronics.com/phoenix6/release/java/'
         links 'https://www.playingwithfusion.com/frc/2022/javadoc/'
         links 'https://codedocs.revrobotics.com/java/'
     }


### PR DESCRIPTION
When #70 was written, `master` only depended on Phoenix 5. Now that `2024-beta` has been merged, `master` also depends on `Phoenix 6`. This PR adds the necessary javadoc link to `build.gradle`.