### PR TITLE
Fix-error-when-accessing-SparkBase.getAbsoluteEncoder().getVelocity()

### DIFF
--- a/src/main/java/org/carlmontrobotics/lib199/sim/MockSparkBase.java
+++ b/src/main/java/org/carlmontrobotics/lib199/sim/MockSparkBase.java
@@ -196,13 +196,16 @@ public class MockSparkBase extends MockedMotorBase {
      */
     public synchronized SparkAbsoluteEncoder getAbsoluteEncoder(SparkAbsoluteEncoder.Type encoderType) {
         if(absoluteEncoder == null) {
-            MockedEncoder absoluteEncoderImpl = new MockedEncoder(SimDevice.create("CANDutyCycle:" + name, port), 0, false, true) {
-                @Override
-                public double getVelocity() {
-                    // A SparkAbsoluteEncoder returns a velocity in rps, not rpm.
-                    return super.getVelocity() / 60.0;
-                }            
-            };
+            MockedEncoder absoluteEncoderImpl = new MockedEncoder(
+                    SimDevice.create("CANDutyCycle:" + name, port), 0, false,
+                    true);
+            // {
+            // @Override
+            // public double getVelocity() {
+            // // A SparkAbsoluteEncoder returns a velocity in rps, not rpm.
+            // return super.getVelocity() / 60.0;
+            // }
+            // };
             absoluteEncoder = Mocks.createMock(SparkAbsoluteEncoder.class, absoluteEncoderImpl, new REVLibErrorAnswer());
         }
         return absoluteEncoder;

--- a/src/main/java/org/carlmontrobotics/lib199/sim/MockSparkBase.java
+++ b/src/main/java/org/carlmontrobotics/lib199/sim/MockSparkBase.java
@@ -198,14 +198,7 @@ public class MockSparkBase extends MockedMotorBase {
         if(absoluteEncoder == null) {
             MockedEncoder absoluteEncoderImpl = new MockedEncoder(
                     SimDevice.create("CANDutyCycle:" + name, port), 0, false,
-                    true);
-            // {
-            // @Override
-            // public double getVelocity() {
-            // // A SparkAbsoluteEncoder returns a velocity in rps, not rpm.
-            // return super.getVelocity() / 60.0;
-            // }
-            // };
+                    true, true);
             absoluteEncoder = Mocks.createMock(SparkAbsoluteEncoder.class, absoluteEncoderImpl, new REVLibErrorAnswer());
         }
         return absoluteEncoder;

--- a/src/main/java/org/carlmontrobotics/lib199/sim/MockedEncoder.java
+++ b/src/main/java/org/carlmontrobotics/lib199/sim/MockedEncoder.java
@@ -45,6 +45,8 @@ public class MockedEncoder implements AbsoluteEncoder, AnalogInput, AutoCloseabl
      * @param absolute Whether the encoder is an absolute encoder. This flag caps the position to
      *        one rotation via. {@link MathUtil#inputModulus(double, double, double)}, disables
      *        {@link #setPosition(double)}, and enables {@link #setZeroOffset(double)}.
+     * 
+     *        {@link #getVelocity()} will return a value in rpm.
      */
     public MockedEncoder(SimDevice device, int countsPerRev, boolean analog,
             boolean absolute) {


### PR DESCRIPTION
Workaround access error when calling getVelocity() on and absolute encoder by moving the functionality from an anonymous subclass to MockedEncoder.