### PR TITLE
Fix Javadoc Action

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -17,13 +17,14 @@ jobs:
     - name: Generate Javadoc
       run: ./gradlew javadoc
     - name: Build Artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ./build/docs/javadoc
   deploy-javadoc:
     needs: build-javadoc
     if: ${{ github.ref == 'refs/heads/master' }}
     permissions:
+      actions: read
       pages: write
       id-token: write
     environment:
@@ -33,4 +34,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
It looks like the javadoc task was failing on #107 because of old artifact dependencies. I didn't think it was appropriate to make the fix part of that PR (because it's a GitHub rather than a WPILib change), so I just bumped the dependency numbers here.